### PR TITLE
enhance authclientcert

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -11,4 +11,3 @@ $conf['fullname_var'] = 'subject, CN';
 $conf['email_var'] = 'extensions, subjectAltName, email';
 $conf['group'] = 'smartcarduser';
 $conf['debug'] = 0;
-

--- a/conf/default.php
+++ b/conf/default.php
@@ -6,6 +6,9 @@
  */
 
 $conf['http_header_name'] = 'HTTP_X_SSL_CLIENTCERT_BASE64';
+$conf['name_var'] = '2.16.840.1.113730.3.1.3';
+$conf['fullname_var'] = 'subject, CN';
+$conf['email_var'] = 'extensions, subjectAltName, email';
 $conf['group'] = 'smartcarduser';
 $conf['debug'] = 0;
 

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -7,6 +7,9 @@
 
 
 $meta['http_header_name'] = array('string');
+$meta['name_var'] = array('string');
+$meta['fullname_var'] = array('string');
+$meta['email_var'] = array('string');
 $meta['group'] = array('string');
 $meta['debug'] = array('onoff','_caution' => 'security');
 


### PR DESCRIPTION
i have changed (tested with apache) the code so i can do assignments at the configuration page in dokuwiki for authclientcerts.
The possibilities are as follows.
The 1. sample and code for the PR is the same as from original author.
  **sample:**
  ```
http_header_name -> HTTP_X_SSL_CLIENTCERT_BASE64
  user name        -> 2.16.840.1.113730.3.1.3
  full name        -> subject, CN
  email            -> extensions, subjectAltName, email
```

2. For this to work you have to change "http_header_name" to SSL_CLIENT_CERT in apache and you need to have **SSLOptions +ExportCertData** to get the pem encoded Cert.
  **sample:**
  ```
http_header_name -> SSL_CLIENT_CERT
  user name        -> subject, UID
  full name        -> subject, CN
  email            -> extensions, subjectAltName, email
```
  
3. Change  "http_header_name" to WEBSRV in apache and you need to have **SSLOptions +StdEnvVars** for the apache environment variable
  **sample:**
```
  http_header_name -> WEBSRV
  user name        -> SSL_CLIENT_S_DN_UID
  full name        -> SSL_CLIENT_S_DN_CN
  email            -> SSL_CLIENT_S_DN_Email

```
